### PR TITLE
feat(stocktake): Phase G — check_map.py + tests + stop-hook

### DIFF
--- a/.claude/hooks/check-architecture-map.sh
+++ b/.claude/hooks/check-architecture-map.sh
@@ -6,27 +6,30 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)" 2>/dev/null || exit 0
 
-# Files modified or untracked in mapped directories (relative to last commit on current branch)
-mapped_dirs="app|core|ff|scripts|docs|eas|tests|\\.claude|\\.github"
+# Mapped paths: stage/appendix-routed top-level dirs + any tracked root file.
+# Root files are `[^/]+$` (no slash anywhere in the path).
+mapped_re='^(deploy/|app/|core/|ff/|scripts/|docs/|eas/|tests/|\.claude/|\.github/|[^/]+$)'
+
+# git status --porcelain output is "XY filename" or "XY old -> new" for renames.
+# Strip the 3-char status prefix, then for renames keep only the new name.
 changed=$(git status --porcelain 2>/dev/null \
-  | awk '{print $2}' \
-  | grep -E "^($mapped_dirs)/" \
+  | sed -e 's/^...//' -e 's/.* -> //' \
+  | grep -E "$mapped_re" \
   || true)
 
 if [ -z "$changed" ]; then
   exit 0
 fi
 
-# If the map itself was touched, all good
+# If the map itself was touched, all good.
 if echo "$changed" | grep -q "^docs/ARCHITECTURE_MAP\.md$"; then
   exit 0
 fi
 
 cat >&2 <<EOF
 [architecture-map nag]
-Code changed in mapped directories this session, but docs/ARCHITECTURE_MAP.md
-was not updated. Update the map (audit verdicts, new files, removed files)
-before ending the session.
+Mapped files changed this session, but docs/ARCHITECTURE_MAP.md was not updated.
+Update the map (audit verdicts, new files, removed files) before ending the session.
 
 Changed files:
 $(echo "$changed" | sed 's/^/  /')

--- a/.claude/hooks/check-architecture-map.sh
+++ b/.claude/hooks/check-architecture-map.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Stop-hook nag: if files in mapped directories changed in this session
+# but docs/ARCHITECTURE_MAP.md didn't, prompt to update before session ends.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" 2>/dev/null || exit 0
+
+# Files modified or untracked in mapped directories (relative to last commit on current branch)
+mapped_dirs="app|core|ff|scripts|docs|eas|tests|\\.claude|\\.github"
+changed=$(git status --porcelain 2>/dev/null \
+  | awk '{print $2}' \
+  | grep -E "^($mapped_dirs)/" \
+  || true)
+
+if [ -z "$changed" ]; then
+  exit 0
+fi
+
+# If the map itself was touched, all good
+if echo "$changed" | grep -q "^docs/ARCHITECTURE_MAP\.md$"; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+[architecture-map nag]
+Code changed in mapped directories this session, but docs/ARCHITECTURE_MAP.md
+was not updated. Update the map (audit verdicts, new files, removed files)
+before ending the session.
+
+Changed files:
+$(echo "$changed" | sed 's/^/  /')
+EOF
+
+exit 1

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,11 @@
             "type": "command",
             "timeout": 5,
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/update-paperwork.sh\""
+          },
+          {
+            "type": "command",
+            "timeout": 5,
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/check-architecture-map.sh\""
           }
         ]
       }

--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -315,6 +315,7 @@ No non-dependabot PRs are currently open (other than this PR if you're reading i
 | `tests/test_routes_data.py` | Web API data routes (list, health, inventory) | ✅ | FastAPI route serialization + response schemas. |
 | `tests/test_groups.py` | Pair group headings (Majors, Crosses, Metals…) | ✅ | Static data source of truth for Data tab. |
 | `tests/test_runner_service_multi_instance.py` | Multi-instance deploy pipeline (active.json, deactivation) | ✅ | Covers instance distribution, filename/ID reconciliation. |
+| `tests/test_check_map.py` | Architecture-map completeness checker (substring + glob coverage + self-paths) | ✅ | 8 cases covering `find_unmapped_files` semantics. Hermetic — no repo state required for the unit tests; one smoke test runs `git ls-files`. |
 
 **Coverage gaps** (worth flagging for Pillars 2 + 3):
 
@@ -359,7 +360,7 @@ No non-dependabot PRs are currently open (other than this PR if you're reading i
 |---|---|---|---|---|
 | `.claude/hooks/session-start.sh` | SessionStart (startup, resume, clear, compact) | Load HANDOFF + PROGRESS; show git log, branch, status, open issues | ✅ | Gracefully degrades if files missing or git unavailable; logs firings to `.claude/hooks/log.txt`. |
 | `.claude/hooks/update-paperwork.sh` | Stop (session end) | HARD BLOCK if HANDOFF stale vs HEAD or real work uncommitted; SOFT WARN if commits landed but PROGRESS untouched | ✅ | Reentry guard avoids re-trigger on same stop event. |
-| `.claude/hooks/check-architecture-map.sh` | _(not yet created — Phase G of this stocktake)_ | Stop-hook nag if mapped-dir code changed but `ARCHITECTURE_MAP.md` didn't | 🔘 | Lands in Phase G alongside `scripts/check_map.py`. |
+| `.claude/hooks/check-architecture-map.sh` | Stop | Nag if mapped-dir files changed in session but `ARCHITECTURE_MAP.md` didn't | ✅ | Wired alongside `update-paperwork.sh` in `settings.json`. Filters changes to `app|core|ff|scripts|docs|eas|tests|.claude|.github` per documented intent. |
 
 ### Commands
 
@@ -386,6 +387,7 @@ No non-dependabot PRs are currently open (other than this PR if you're reading i
 | `scripts/ff_start_server.ps1` | Start uvicorn directly (discouraged) | ❌ | Superseded by `ff_restart_server.ps1`; CLAUDE.md forbids direct use. Cleanup candidate. |
 | `scripts/pre-pr.ps1` | Pre-PR review ritual: run Codex mini as read-only reviewer on diff vs main | ✅ | Part of sanctioned workflow. Output to `artifacts/` for pasting into PR. |
 | `scripts/migrate_best_trial_fingerprint.py` | Backfill `signal_family` + `signal_params` into old `deploy/live` configs | ✅ | Idempotent one-shot migration (BUG-variant-id-not-stable-2026-04-22); safe to re-run. |
+| `scripts/check_map.py` | Architecture-map completeness checker (the load-bearing acceptance criterion) | ✅ | Walks `git ls-files`; exits non-zero if any tracked file isn't referenced in `ARCHITECTURE_MAP.md` (literal substring or backtick-wrapped glob). Tested by `tests/test_check_map.py`. |
 | `scripts/desktop/Check Fire Forex.bat` | Status check — see if live runner is alive and what it's doing | ✅ | Desktop shortcut for VPS; read-only. |
 | `scripts/desktop/Deploy Fire Forex.bat` | Deploy & kick off trading (orchestrates git pull, runner restart, trial setup) | ✅ | Primary laptop→VPS deployment button. |
 | `scripts/desktop/Diagnose Fire Forex.bat` | Full diagnostic dump (MT5 positions, task state, config shape, git HEAD, logs) | ✅ | Read-only debug tool; safe any time. |

--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -388,6 +388,7 @@ No non-dependabot PRs are currently open (other than this PR if you're reading i
 | `scripts/pre-pr.ps1` | Pre-PR review ritual: run Codex mini as read-only reviewer on diff vs main | ✅ | Part of sanctioned workflow. Output to `artifacts/` for pasting into PR. |
 | `scripts/migrate_best_trial_fingerprint.py` | Backfill `signal_family` + `signal_params` into old `deploy/live` configs | ✅ | Idempotent one-shot migration (BUG-variant-id-not-stable-2026-04-22); safe to re-run. |
 | `scripts/check_map.py` | Architecture-map completeness checker (the load-bearing acceptance criterion) | ✅ | Walks `git ls-files`; exits non-zero if any tracked file isn't referenced in `ARCHITECTURE_MAP.md` (literal substring or backtick-wrapped glob). Tested by `tests/test_check_map.py`. |
+| `scripts/__init__.py` | Package marker so `tests/test_check_map.py` can `from scripts.check_map import …` on CI | ✅ | One-liner; tests-only requirement. |
 | `scripts/desktop/Check Fire Forex.bat` | Status check — see if live runner is alive and what it's doing | ✅ | Desktop shortcut for VPS; read-only. |
 | `scripts/desktop/Deploy Fire Forex.bat` | Deploy & kick off trading (orchestrates git pull, runner restart, trial setup) | ✅ | Primary laptop→VPS deployment button. |
 | `scripts/desktop/Diagnose Fire Forex.bat` | Full diagnostic dump (MT5 positions, task state, config shape, git HEAD, logs) | ✅ | Read-only debug tool; safe any time. |

--- a/docs/ARCHITECTURE_MAP.md
+++ b/docs/ARCHITECTURE_MAP.md
@@ -360,7 +360,7 @@ No non-dependabot PRs are currently open (other than this PR if you're reading i
 |---|---|---|---|---|
 | `.claude/hooks/session-start.sh` | SessionStart (startup, resume, clear, compact) | Load HANDOFF + PROGRESS; show git log, branch, status, open issues | ✅ | Gracefully degrades if files missing or git unavailable; logs firings to `.claude/hooks/log.txt`. |
 | `.claude/hooks/update-paperwork.sh` | Stop (session end) | HARD BLOCK if HANDOFF stale vs HEAD or real work uncommitted; SOFT WARN if commits landed but PROGRESS untouched | ✅ | Reentry guard avoids re-trigger on same stop event. |
-| `.claude/hooks/check-architecture-map.sh` | Stop | Nag if mapped-dir files changed in session but `ARCHITECTURE_MAP.md` didn't | ✅ | Wired alongside `update-paperwork.sh` in `settings.json`. Filters changes to `app|core|ff|scripts|docs|eas|tests|.claude|.github` per documented intent. |
+| `.claude/hooks/check-architecture-map.sh` | Stop | Nag if mapped files changed in session but `ARCHITECTURE_MAP.md` didn't | ✅ | Wired alongside `update-paperwork.sh` in `settings.json`. Filters changes to mapped dirs (`deploy/`, `app/`, `core/`, `ff/`, `scripts/`, `docs/`, `eas/`, `tests/`, `.claude/`, `.github/`) plus any tracked root file. |
 
 ### Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ manifest-path = "core/Cargo.toml"
 module-name = "ff_core"
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 markers = [
     "slow: long-running end-to-end tests (~1s+); skip with -m 'not slow'",
 ]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Operational scripts. Tests import from here via `from scripts.X import ...`."""

--- a/scripts/check_map.py
+++ b/scripts/check_map.py
@@ -21,6 +21,13 @@ SELF_PATHS = {
     "tests/test_check_map.py",
 }
 
+# Characters that count as "part of a file path" for boundary checks. A path
+# only matches when the surrounding characters are NOT in this set — so
+# `api.py` does not match inside `app/api.py`.
+_PATH_CHAR = "A-Za-z0-9_./-"
+
+_GLOB_PATTERN_RE = re.compile(r"`([A-Za-z0-9_./*-]+\*[A-Za-z0-9_./*-]*)`")
+
 
 def load_tracked_files(root: Path) -> set[str]:
     """Return all tracked files (POSIX paths relative to ``root``)."""
@@ -38,37 +45,35 @@ def load_map_text(map_path: Path = MAP_PATH) -> str:
     return map_path.read_text(encoding="utf-8")
 
 
-_GLOB_PATTERN_RE = re.compile(r"`([A-Za-z0-9_./*-]+\*[A-Za-z0-9_./*-]*)`")
-
-
 def _extract_glob_patterns(map_text: str) -> list[str]:
-    """Pull every backtick-wrapped path containing ``*`` out of the map.
-
-    Examples matched: ``docs/builds/2026-04-19-chandelier-stop/*``,
-    ``docs/validation/2026-04-19-*/``.
-    """
+    """Pull every backtick-wrapped path containing ``*`` out of the map."""
     return _GLOB_PATTERN_RE.findall(map_text)
 
 
+def _path_is_referenced(path: str, map_text: str) -> bool:
+    """True if ``path`` appears in ``map_text`` as a delimited token.
+
+    Avoids false positives where one path is a substring of another (e.g.
+    ``api.py`` should NOT match inside ``app/api.py``). The path must be
+    bounded on both sides by characters that aren't path-identifier chars.
+    """
+    pattern = rf"(?<![{_PATH_CHAR}]){re.escape(path)}(?![{_PATH_CHAR}])"
+    return re.search(pattern, map_text) is not None
+
+
 def _path_is_wildcarded(path: str, patterns: list[str]) -> bool:
-    """True if any glob pattern from the map matches ``path`` (or its directory prefix)."""
+    """True if any backtick-wrapped glob from the map matches ``path``."""
     for pat in patterns:
-        # Trailing slash means "any file under this dir" — fnmatch needs `/*` for that.
         normalised = f"{pat}*" if pat.endswith("/") else pat
         if fnmatch.fnmatchcase(path, normalised):
-            return True
-        # Also match against the path's parent directory (covers `dir/*` patterns
-        # written without `**` against arbitrarily deep tracked files).
-        parent = path.rsplit("/", 1)[0] + "/" if "/" in path else ""
-        if parent and fnmatch.fnmatchcase(parent, normalised + "/"):
             return True
     return False
 
 
 def find_unmapped_files(tracked: set[str], map_text: str) -> set[str]:
-    """Files whose path does not appear (anywhere — backticks, prose, or glob pattern) in the map."""
+    """Files whose path does not appear (as a delimited token or glob match) in the map."""
     patterns = _extract_glob_patterns(map_text)
-    return {p for p in tracked if p not in SELF_PATHS and p not in map_text and not _path_is_wildcarded(p, patterns)}
+    return {p for p in tracked if p not in SELF_PATHS and not _path_is_referenced(p, map_text) and not _path_is_wildcarded(p, patterns)}
 
 
 def main() -> int:

--- a/scripts/check_map.py
+++ b/scripts/check_map.py
@@ -1,0 +1,94 @@
+"""Architecture-map completeness checker.
+
+Walks every tracked file in the repo and warns if any aren't referenced in
+``docs/ARCHITECTURE_MAP.md``. Exits non-zero on miss so CI can fail.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAP_PATH = REPO_ROOT / "docs" / "ARCHITECTURE_MAP.md"
+
+SELF_PATHS = {
+    "docs/ARCHITECTURE_MAP.md",
+    "scripts/check_map.py",
+    "tests/test_check_map.py",
+}
+
+
+def load_tracked_files(root: Path) -> set[str]:
+    """Return all tracked files (POSIX paths relative to ``root``)."""
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def load_map_text(map_path: Path = MAP_PATH) -> str:
+    return map_path.read_text(encoding="utf-8")
+
+
+_GLOB_PATTERN_RE = re.compile(r"`([A-Za-z0-9_./*-]+\*[A-Za-z0-9_./*-]*)`")
+
+
+def _extract_glob_patterns(map_text: str) -> list[str]:
+    """Pull every backtick-wrapped path containing ``*`` out of the map.
+
+    Examples matched: ``docs/builds/2026-04-19-chandelier-stop/*``,
+    ``docs/validation/2026-04-19-*/``.
+    """
+    return _GLOB_PATTERN_RE.findall(map_text)
+
+
+def _path_is_wildcarded(path: str, patterns: list[str]) -> bool:
+    """True if any glob pattern from the map matches ``path`` (or its directory prefix)."""
+    for pat in patterns:
+        # Trailing slash means "any file under this dir" — fnmatch needs `/*` for that.
+        normalised = f"{pat}*" if pat.endswith("/") else pat
+        if fnmatch.fnmatchcase(path, normalised):
+            return True
+        # Also match against the path's parent directory (covers `dir/*` patterns
+        # written without `**` against arbitrarily deep tracked files).
+        parent = path.rsplit("/", 1)[0] + "/" if "/" in path else ""
+        if parent and fnmatch.fnmatchcase(parent, normalised + "/"):
+            return True
+    return False
+
+
+def find_unmapped_files(tracked: set[str], map_text: str) -> set[str]:
+    """Files whose path does not appear (anywhere — backticks, prose, or glob pattern) in the map."""
+    patterns = _extract_glob_patterns(map_text)
+    return {p for p in tracked if p not in SELF_PATHS and p not in map_text and not _path_is_wildcarded(p, patterns)}
+
+
+def main() -> int:
+    if not MAP_PATH.exists():
+        print(f"ERROR: {MAP_PATH} does not exist", file=sys.stderr)
+        return 2
+
+    tracked = load_tracked_files(REPO_ROOT)
+    map_text = load_map_text(MAP_PATH)
+    unmapped = find_unmapped_files(tracked, map_text)
+
+    if not unmapped:
+        print(f"OK: all {len(tracked)} tracked files referenced in ARCHITECTURE_MAP.md")
+        return 0
+
+    print(f"FAIL: {len(unmapped)} tracked files are not referenced in ARCHITECTURE_MAP.md:")
+    for path in sorted(unmapped):
+        print(f"  {path}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_map.py
+++ b/tests/test_check_map.py
@@ -1,0 +1,74 @@
+"""Tests for scripts.check_map — the architecture-map completeness checker."""
+
+from pathlib import Path
+
+from scripts.check_map import find_unmapped_files, load_map_text, load_tracked_files
+
+
+def test_unmapped_when_file_missing_from_map() -> None:
+    tracked = {"ff/x.py", "ff/y.py"}
+    map_text = "## Stage\n- `ff/x.py`\n"
+
+    assert find_unmapped_files(tracked, map_text) == {"ff/y.py"}
+
+
+def test_no_unmapped_when_all_files_referenced() -> None:
+    tracked = {"ff/x.py", "ff/y.py"}
+    map_text = "Stage 1: `ff/x.py` and `ff/y.py`."
+
+    assert find_unmapped_files(tracked, map_text) == set()
+
+
+def test_path_match_is_substring_not_exact() -> None:
+    """A path appearing inside backticks-with-suffix should still count as referenced."""
+    tracked = {"app/routes.py"}
+    map_text = "See `app/routes.py:123-145` for the issue."
+
+    assert find_unmapped_files(tracked, map_text) == set()
+
+
+def test_wildcard_dir_reference_covers_files_under_it() -> None:
+    """A `dir/*` reference in the map covers any tracked file under that dir."""
+    tracked = {
+        "docs/builds/2026-04-19-chandelier-stop/01-mechanics-brief.md",
+        "docs/builds/2026-04-19-chandelier-stop/02-slot-map.md",
+    }
+    map_text = "See `docs/builds/2026-04-19-chandelier-stop/*` (6 files) for evidence."
+
+    assert find_unmapped_files(tracked, map_text) == set()
+
+
+def test_wildcard_does_not_over_match_unrelated_dirs() -> None:
+    """A wildcard for one dir doesn't accidentally cover sibling dirs."""
+    tracked = {"docs/other/file.md"}
+    map_text = "See `docs/builds/2026-04-19-chandelier-stop/*` for evidence."
+
+    assert find_unmapped_files(tracked, map_text) == {"docs/other/file.md"}
+
+
+def test_self_paths_are_excluded() -> None:
+    """The map and the checker itself don't have to reference themselves."""
+    tracked = {
+        "docs/ARCHITECTURE_MAP.md",
+        "scripts/check_map.py",
+        "tests/test_check_map.py",
+        "ff/x.py",
+    }
+    map_text = "Talks about `ff/x.py` only."
+
+    assert find_unmapped_files(tracked, map_text) == set()
+
+
+def test_load_map_text_reads_real_file(tmp_path: Path) -> None:
+    map_file = tmp_path / "MAP.md"
+    map_file.write_text("hello world\n", encoding="utf-8")
+
+    assert load_map_text(map_file) == "hello world\n"
+
+
+def test_load_tracked_files_runs_against_real_repo() -> None:
+    """Smoke — load_tracked_files invokes git ls-files and returns at least one expected file."""
+    repo_root = Path(__file__).resolve().parent.parent
+    tracked = load_tracked_files(repo_root)
+
+    assert "docs/ARCHITECTURE_MAP.md" in tracked

--- a/tests/test_check_map.py
+++ b/tests/test_check_map.py
@@ -46,6 +46,14 @@ def test_wildcard_does_not_over_match_unrelated_dirs() -> None:
     assert find_unmapped_files(tracked, map_text) == {"docs/other/file.md"}
 
 
+def test_short_path_is_not_matched_inside_longer_path() -> None:
+    """A root file `api.py` should NOT be considered referenced by `app/api.py`."""
+    tracked = {"api.py"}
+    map_text = "Web routes: `app/api.py` handles things."
+
+    assert find_unmapped_files(tracked, map_text) == {"api.py"}
+
+
 def test_self_paths_are_excluded() -> None:
     """The map and the checker itself don't have to reference themselves."""
     tracked = {


### PR DESCRIPTION
## Summary

Phase G of the Architecture Stocktake — the load-bearing acceptance criterion that prevents the map from silently drifting.

Adds three things:

1. **`scripts/check_map.py`** — walks `git ls-files`, exits non-zero if any tracked file isn't referenced in `docs/ARCHITECTURE_MAP.md` (literal substring OR backtick-wrapped glob like `docs/builds/.../*` or `docs/validation/2026-04-19-*/`). Verified: reports OK on all 239 tracked files.
2. **`tests/test_check_map.py`** — 8 unit + smoke tests covering the substring matching, glob patterns, self-paths exclusion, and `git ls-files` smoke.
3. **`.claude/hooks/check-architecture-map.sh`** — Stop-hook nag. If files in mapped dirs (`app|core|ff|scripts|docs|eas|tests|.claude|.github`) changed in the session but `ARCHITECTURE_MAP.md` didn't, prompt to update before session ends. Filtered to mapped dirs (per documented intent) to avoid false-positive nags from unrelated edits. Registered in `.claude/settings.json` alongside the existing `update-paperwork.sh` Stop hook.

Map updated: Appendix C/E/F now include the new files; Appendix E's Phase-C 🔘 row for the hook is now ✅.

**Note:** This branch was opened off `main` before PR #20 (Phase D+E+F) merged, so it does not yet include the cleanup punch list / roadmap / mermaid. After #20 merges, this branch will rebase trivially onto main (no overlapping edits — D+E+F touches Sections 7/8 + the top-of-file mermaid placeholder; G touches Appendix C/E/F + adds new files).

## Self-review checklist

- [x] Every changed function has a test — `find_unmapped_files`, `_extract_glob_patterns`, `_path_is_wildcarded` covered via the 8 test cases
- [x] No `==` on floats — N/A, no float math
- [x] No `print()` or debug logging left in — `print()` is the script's intended output (operator-facing CLI)
- [x] No silently-changed parameter defaults — N/A
- [x] No new `TODO` / `FIXME` comments — confirmed
- [x] `CLAUDE.md` / rules / `PROGRESS.md` updated if the change touches them — Phase I will refresh HANDOFF + tick PROGRESS
- [x] `pytest tests/test_check_map.py` passed locally — 8/8 green
- [x] `cargo test` passed locally — N/A, no Rust touched
- [x] `pre-commit run --all-files` passed locally — pre-commit ran on the commit (ruff format applied, then re-committed)
- [x] Parity harness still matches — N/A, no live-runner / signal code

## Review outputs

**`/simplify` and Codex mini:** not run on this small code-only diff.
**CodeRabbit + Gemini:** awaiting auto-review on this PR.

## Test plan

- [x] `python scripts/check_map.py` exits 0 on full repo
- [x] `pytest tests/test_check_map.py` 8/8 green
- [ ] CodeRabbit / Gemini review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated architecture-map validation that runs at session stop and prevents completion when changed files aren’t covered.

* **Tests**
  * Added a comprehensive test suite validating unmapped-file detection, wildcard matching, exclusion rules, and repository interactions.

* **Documentation**
  * Updated the architecture map and docs to describe the validator, its behavior, test expectations, and CI wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->