### PR TITLE
docs: refresh HANDOFF + tick PROGRESS for today's 12 PRs

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,70 +1,77 @@
-# Handoff — 2026-04-25 (Pillar 1: Architecture stocktake — SHIPPED)
+# Handoff — 2026-04-25 (MT5 direct ingest shipped; ready for Pillar 5)
 
-**Branch:** `feat/stocktake-phase-i` (this branch); `main` synced through PR #21.
-**Status:** Pillar 1 of the 6-pillar programme complete. The map is live, the cleanup punch list is executed, the completeness checker + stop-hook keep it from drifting. Pillars 2–6 are sketched in the map's roadmap section, ready to start.
+**Branch:** `feat/refresh-handoff` (this PR); `main` synced through PR #26.
+**Status:** Today landed Pillar 1 (architecture stocktake), cleanup pass 2, PR-system refinements, MT5 direct-query toolkit, and 3 of 10 dependabot bumps. The next move is Pillar 5 (live↔backtest parity) using the new MT5 toolkit.
 
-## Done this session — full Pillar 1 stocktake
+## What landed today (12 PRs merged)
 
-| Phase | What | PR |
-|---|---|---|
-| A | Inventory skeleton — every tracked file bucketed by stage | #16 |
-| B | Per-stage audit tables (Stages 1–6) with verdicts | #18 |
-| C | Appendices A–I (docs / PRs / tests / CI / .claude / scripts / root / configs / artifacts) — built via 9 parallel research subagents | #19 |
-| D+E+F | Cleanup punch list + Pillars 2–6 roadmap + top-of-map Mermaid | #20 |
-| G | `scripts/check_map.py` + `tests/test_check_map.py` (9 tests) + `.claude/hooks/check-architecture-map.sh` stop-hook | #21 |
-| H | Executed deletions: 9 files removed (5 dated session journals, 3 superseded deploy bundles, 1 superseded server script) | #22 |
-| I | This PR — tick PROGRESS, refresh HANDOFF, link from CLAUDE.md | (this branch) |
+### Stocktake (Pillar 1) — DONE
+- **#16, #18, #19** — Phases A/B/C: file inventory, per-stage audit tables, 9 appendices via parallel agents.
+- **#20** — Phases D/E/F: cleanup punch list, Pillars 2–6 roadmap, mermaid flow diagram.
+- **#21** — Phase G: `scripts/check_map.py` + 9 tests + `.claude/hooks/check-architecture-map.sh` stop-hook nag.
+- **#22** — Phase H: 9 high-confidence stale-doc deletions executed.
+- **#23** — Phase I: PROGRESS ticked, HANDOFF refreshed, CLAUDE.md links to map.
+
+### Cleanup + PR system
+- **#24** — cleanup pass 2: deleted 10 more stale docs (`ROADMAP.md`, `rust-wishlist.md`, `CHANGES.md`, `REVIEW.md`, `exec-full-fix-plan.md`, `bug-hunting-research-brief.md`, 3× dated `docs/live/` files, `snapshot-home.md`).
+- **#25** — PR-system refinements (5 changes from the stocktake retrospective):
+  1. CLAUDE.md "Do" — explicit batching rule for tool calls
+  2. `pr-checklist.yml` — auto-skip on docs-only PRs
+  3. `workflow.md` — CodeRabbit named primary, Gemini = second opinion; combine-related-phases policy
+  4. `settings.json` — drop the local force-push deny rules (branch protection on `main` is the real gate)
+  5. `.gitignore` — patterns for `_pre_pr_diff.patch`, `review-*.md`, `_pr_*.md`
+
+### MT5 direct toolkit
+- **#26** — `scripts/import_mt5_report.py` + `scripts/mt5_status.py` + 2 desktop shortcuts.
+  - Both hit the running MT5 terminal directly via `MetaTrader5` Python package — **no manual HTML export needed**.
+  - Broker→UTC offset applied on connect (probe live EURUSD tick vs wall-clock UTC, same pattern as `ff/live/broker_mt5.py`). Avoids the broker-local timezone bug from 2026-04-22.
+  - SL/TP enriched via `history_orders_get` (deals don't carry SL/TP).
+  - Spread calc digit-aware (`info.digits`), works for FX + Gold + Index symbols.
+  - `mt5_status.py` shows: account balance / equity / floating P&L, every open position with unrealised P&L + SL + TP, every pending order, live spread + swap per symbol.
+
+### Dependabot (3 of 10)
+- **#3** actions/checkout v6 · **#6** fastapi · **#7** pytest — all merged.
+- 5 stale (need `@dependabot rebase`): #1 rayon, #2 codeql-action v4, #4 actions/cache v5, #5 dukascopy-python, #8 maturin.
+- 2 with merge conflicts after siblings landed: #9 httpx, #10 pyyaml.
+
+## Live state RIGHT NOW (per `scripts/mt5_status.py` against ICMarkets demo terminal)
+
+- **Account #52754648** (ICMarketsSC-Demo): £2,918 balance, £2,910 equity, **-£8 floating P&L**.
+- **67 currently open positions** across ~20 currency pairs.
+- **14-day actual: 457 closed trades, 41% wins, net -£38**.
+- Mix of `fireforex` (legacy) + per-strategy comments (`ff_ema_cross`, `ff_macd_cross`, `ff_donchian`).
+- The user's earlier 18-trade HTML report (17/18 losses on 2026-04-23/24) was a slice; the broader 14-day picture is bad-but-not-catastrophic.
+
+## What's next — concrete priority order
+
+1. **Pillar 5 — live↔backtest parity (start here):** flow the 14-day MT5 trade history through reconciliation against backtest replay. The active deploy is `complexity_L10_EUR_USD_M15_*` × 3 instances trading 20+ pairs in portfolio mode. Compare each closed trade vs what backtest says should have happened. The 41% WR is the gap to diagnose.
+2. **Live trade management toolkit (extends MT5 work):** `mt5.order_send(action=TRADE_ACTION_SLTP, ...)` to adjust SL/TP on open positions; emergency close-all from laptop; live diff "config says trade X pairs, MT5 has positions on Y pairs"; real-time spread monitor. Today the live runner only PLACES orders — it never re-touches them.
+3. **Triage remaining dependabot PRs:** comment `@dependabot rebase` on #1, #2, #4, #5, #8, #9, #10. (Mass-commenting on PRs needs explicit user OK per agent-permission policy.)
+4. **Open issues:** #12 (path-traversal in `app/routes.py`), #13 (sig_bar_index OOB in `core/src/trade_full.rs`), #14 (`win_rate` vs `win_rate_pct` mismatch).
+5. **Pillar 2 (Multi-optimiser bench):** Optuna / CMA-ES / walk-forward — only after parity is healthy.
 
 ## Where to look
 
-- **The map:** `docs/ARCHITECTURE_MAP.md` — long, vertical, audit-style. Top-of-file Mermaid → 6 stage tables → 9 appendices → cleanup punch list (Section 7) → Pillars 2–6 roadmap (Section 8).
-- **Spec:** `docs/superpowers/specs/2026-04-25-architecture-stocktake-design.md`
-- **Plan:** `docs/superpowers/plans/2026-04-25-architecture-stocktake.md`
-- **Checker:** `python scripts/check_map.py` — exits 0 when all tracked files are referenced; exits 1 with the missing list otherwise.
-- **Stop-hook:** fires on session end if mapped-dir files changed but the map didn't.
-
-## Audit findings worth attention (still open)
-
-Cross-referenced from the map's appendices:
-
-- **Issue #12** — Path-traversal in `app/routes.py` (Stage 4). Open.
-- **Issue #13** — Out-of-bounds risk on `sig_bar_index` in `core/src/trade_full.rs` (Stage 3). Open.
-- **Issue #14** — Metric key mismatch `win_rate` vs `win_rate_pct` (Stages 3 + 4). Open. Map verdicts on `core/src/metrics.rs` and `ff/harness.py` are ⚠️ until this is fixed.
-- **`core/src/lib.rs` `allow(dead_code)` list** — `SL_FIXED_PIPS / TP_RR_RATIO / TRAIL_ATR_CHANDELIER / M_DSR / tp_pips` reserved for upcoming variants. Decide per-name in a follow-on PR.
-- **`artifacts/history.csv`** — known concurrency bugs from 2026-04-19 audit (race in `harness.py` append, lock released too early in `jobs.py`). Pillar 3 work.
-
-## What's next — Pillars 2–6
-
-Per the map's Section 8 roadmap:
-
-1. ✅ Pillar 1 — Honest map & cleanup (THIS PR closes it)
-2. **Pillar 2 — Multi-optimiser bench** (Bayesian / CMA-ES / walk-forward + experiment tracker). Medium-large effort. Nothing blocking.
-3. Pillar 3 — Safety & stability (Monte Carlo, paper-trade gate, scheduled data sweeps, history.csv concurrency fixes). Medium effort.
-4. Pillar 4 — Dashboards & insight (full UI, equity / drawdown / sensitivity). Large effort. Issue #14 must land first.
-5. Pillar 5 — Drift detection & feedback loops (auto BT⇄live parity loop, three-tier data architecture). Big project.
-6. Pillar 6 — New-EA development workflow (template, mandatory pipeline, side-by-side compare). Medium effort.
-
-## Open dependabot PRs (still waiting triage)
-
-10 auto-opened 2026-04-25: rayon, actions/cache@5, actions/checkout@6, codeql-action@4, dukascopy-python, fastapi, httpx, maturin, pytest, pyyaml. Likely batch-mergeable after `pytest` run.
+- **The map:** `docs/ARCHITECTURE_MAP.md` — top-of-file Mermaid + 6 stage tables + 9 appendices + Section 7 (cleanup) + Section 8 (Pillars 2–6 roadmap).
+- **The MT5 toolkit:** `scripts/import_mt5_report.py` (history) + `scripts/mt5_status.py` (live state) + `scripts/desktop/{Import MT5 Report,Show MT5 Status}.bat` (one-click).
+- **Workflow rules:** `.claude/rules/workflow.md` — MT5 conventions are codified in the "MT5 — direct-query conventions" section.
+- **Completeness checker:** `python scripts/check_map.py` — exits 0 when every tracked file is referenced. The Stop-hook nag fires automatically if you change mapped files but not the map.
 
 ## Failed approaches — DON'T REPEAT
 
-- Initial pre-commit config used auto-fixers (caused stash-conflict oscillation on Windows). Now check-only.
-- ruff version mismatch between local and pre-commit caused style oscillation. Now pinned to v0.15.12.
-- Cargo clippy in pre-commit needs Python on PATH for pyo3 — removed from pre-commit, kept in CI.
-- Tried to admin-merge PR #11 to bypass branch protection. Wrong instinct. Right call was to address review threads.
-- Phase B PR #17 was stacked on Phase A's branch (`feat/stocktake-phase-a`). When Phase A merged via squash, GitHub auto-closed #17 (its base disappeared). Worked around by opening PR #18 from a rebased branch. Lesson: rebase stacked PRs onto main once the base merges; don't try to retarget — GitHub handles deletes harshly.
-- Initial Phase D cleanup list flagged ALL 6 dated `deploy/instances/*` bundles for deletion. CodeRabbit caught that 3 of them are listed in `active.json` as the live trading instances. Per-file verification against `active.json` is now mandatory before flagging deploy bundles for deletion.
-- Phase C audit reported CLAUDE.md as 181 lines, but that was reading the local working-tree (with uncommitted session-start mods). Always check `git show origin/main:<path>` for canonical line counts when auditing.
+- **Initial PR-system pattern: 7 PRs for one logical task.** The stocktake split into 7 PRs cost ~5–10 min CI/review wait per cycle. New rule (in `workflow.md`): bundle related phases when same file / docs-only / under ~300 lines.
+- **HTML fallback in MT5 importer.** Built it first; user pushed back ("why are we not going direct?"). Removed in PR #26. Lesson: lead with the canonical mechanism, don't ship "and also a fallback" by default.
+- **Forgot broker→UTC offset on first MT5 importer pass.** Same trap as the 2026-04-22 deal-history bug (`MT5 Deal History Query Timezone Corrected to Broker Time` memory). Now codified in `workflow.md`: never trust raw MT5 `time` fields as UTC.
+- **MT5 status script crashed on Windows cp1252 stdout** (used `→` arrow). Now reconfigures stdout to UTF-8 at script start; same pattern in both new scripts.
+- **Phase C audit reported CLAUDE.md as 181 lines** — that was reading the local working tree (with uncommitted session-start mods). Always check `git show origin/main:<path>` for canonical line counts.
+- **Initial cleanup list flagged ALL 6 dated `deploy/instances/*` bundles** for deletion. CodeRabbit caught: 3 of them (the 04-24 set) are listed in `active.json` as live trading instances. Per-file verification against `active.json` is mandatory before flagging deploy bundles for deletion.
+- **Stacked PRs (#17 stacked on Phase A's branch)** auto-closed when Phase A merged via squash. Worked around with a fresh branch (PR #18). Never stack on a branch that's about to merge.
+- **Serial single-tool-call turns** wasted user-visible cycles ("you keep stopping"). Now codified in CLAUDE.md "Do": batch independent edits / reads / bash into ONE response.
 
 ## Resume steps for next session
 
 1. SessionStart hook injects HANDOFF + PROGRESS + recent commits + open issues.
-2. Pillar 1 is done — start Pillar 2 (Multi-optimiser bench) when ready.
-3. The map (`docs/ARCHITECTURE_MAP.md`) is the source of truth. Trust the verdicts, address the ⚠️/❌ rows in priority order.
-4. The completeness checker keeps the map honest — don't add a tracked file without a row in the map (the stop-hook will nag, the checker will fail CI).
-
-## Live↔BT parity work
-
-Still queued. Resumes in Pillar 5.
+2. Run `python scripts/mt5_status.py` to see current live state at session start.
+3. Run `python scripts/import_mt5_report.py --days 14` to get fresh trade history into `artifacts/live/incoming/`.
+4. Start Pillar 5 work: build a comparison script that takes that fresh history + replays backtest for the same window with the same EA config + classifies each trade as match/better/worse/missing/extra.
+5. The completeness checker keeps the map honest — don't add a tracked file without a row.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -23,6 +23,10 @@ Living milestone register. Tick boxes as things ship. Never rewritten — only a
 ## Next
 
 - [x] **Architecture stocktake — Pillar 1** (shipped 2026-04-25, PRs #16, #18, #19, #20, #21, #22, #23) — `docs/ARCHITECTURE_MAP.md` + completeness checker (`scripts/check_map.py`) + stop-hook (`.claude/hooks/check-architecture-map.sh`) + Pillars 2–6 roadmap. 9 cleanup files removed; 231 tracked files audited.
+- [x] **Cleanup pass 2** (shipped 2026-04-25, PR #24) — 10 more stale docs removed (`ROADMAP.md`, `rust-wishlist.md`, `CHANGES.md`, `REVIEW.md`, `exec-full-fix-plan.md`, `bug-hunting-research-brief.md`, 3× dated `docs/live/` files, `snapshot-home.md`).
+- [x] **PR-system refinements** (shipped 2026-04-25, PR #25) — batching rule, docs-only checklist auto-skip, CodeRabbit-primary policy, force-push allowed on feature branches, gitignore patterns for transient PR artifacts.
+- [x] **MT5 direct toolkit** (shipped 2026-04-25, PR #26) — `scripts/import_mt5_report.py` + `scripts/mt5_status.py` + 2 desktop shortcuts. Hits the running MT5 terminal directly (no manual HTML export). Broker→UTC offset, SL/TP enrichment, digit-aware spread.
+- [x] **Dependabot triage (3 of 10)** (2026-04-25, PRs #3, #6, #7) — actions/checkout v6, fastapi, pytest merged. Remaining 7 need `@dependabot rebase`.
 - [ ] **Address review-flagged bugs**:
   - [ ] #12 Path-traversal validation in `app/routes.py`
   - [ ] #13 Out-of-bounds bounds check on `sig_bar_index`


### PR DESCRIPTION
Paperwork refresh after a long session.

HANDOFF rewritten to reflect:
- All 12 PRs that landed today (stocktake A-I, cleanup pass 2, PR-system, MT5 toolkit, 3 dependabot)
- Live state from the new MT5 status script (67 open positions, 14d 41% WR, -£8 floating)
- Concrete next-priority order: Pillar 5 parity > live trade management > dependabot rebase > Pillars 2/3/4
- Failed approaches expanded: stacked PRs, HTML fallback, broker-local time, serial tool calls

PROGRESS ticked for the 4 new shipped milestones.

Docs-only PR — checklist auto-skip should fire (per PR #25).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project documentation to reflect completed milestones including infrastructure cleanup and workflow refinements.
  * Documented MT5 direct toolkit enhancements for status tracking and data import processes.
  * Consolidated progress tracking with updated next steps and priority list for ongoing development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->